### PR TITLE
Revert cancellation retries

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -26,10 +26,9 @@ const (
 
 // Snowflake Server Error code
 const (
-	sessionExpiredCode                 = "390112"
-	queryInProgressCode                = "333333"
-	queryInProgressAsyncCode           = "333334"
-	statementNotCurrentlyExecutingCode = 605 // "000605"
+	sessionExpiredCode       = "390112"
+	queryInProgressCode      = "333333"
+	queryInProgressAsyncCode = "333334"
 )
 
 // Snowflake Server Endpoints
@@ -154,20 +153,9 @@ func postRestfulQuery(
 		return data, err
 	}
 
-	const numRetries = 3
-	for i := 0; i < numRetries; i++ {
-		err = sr.FuncCancelQuery(context.TODO(), sr, requestID, timeout)
-
-		sfError, ok := err.(*SnowflakeError)
-		if ok && sfError.Number == statementNotCurrentlyExecutingCode {
-			// Try again in a second, in case we tried to cancel too quickly
-			time.Sleep(time.Second)
-			continue
-		} else if err != nil {
-			return nil, err
-		} else {
-			break
-		}
+	err = sr.FuncCancelQuery(context.TODO(), sr, requestID, timeout)
+	if err != nil {
+		return nil, err
 	}
 	return nil, ctx.Err()
 }


### PR DESCRIPTION
### Description
The cancellation attempts can lead to rather long delays (10+ seconds) when running queries, which can cause issues in some clients, so revert these retries. We will have to find another way to fix the queries that fail to get canceled (or hopefully snowflake will have a fix for them).
