### PR TITLE
export simpleTokenAccessor for testing

### DIFF
--- a/export.go
+++ b/export.go
@@ -10,6 +10,7 @@ type SnowflakeRows = snowflakeRows
 type SnowflakeRestful = snowflakeRestful
 type SnowflakeValue = snowflakeValue
 type ChunkRowType = chunkRowType
+type SimpleTokenAccessor = simpleTokenAccessor
 
 // Methods
 


### PR DESCRIPTION
snowflakeRestful.Token has been replaced by TokenAccessor. In testing,
we need to provide a fake TokenAccessor, which is simpleTokenAccessor.

Exporting it means we can reuse the fake in our unit tests.