### PR TITLE
Fix rebase and some (stupid) linter issues

### DIFF
--- a/chunk_test.go
+++ b/chunk_test.go
@@ -5,11 +5,13 @@ package gosnowflake
 import (
 	"bytes"
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -391,10 +393,64 @@ func TestWithStreamDownloader(t *testing.T) {
 		}
 	})
 }
+
+func TestWithArrowBatches(t *testing.T) {
+	ctx := WithArrowBatches(context.Background())
+	numrows := 3000 // approximately 6 ArrowBatch objects
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Error(err)
+	}
+	sc, err := buildSnowflakeConn(ctx, *config)
+	if err != nil {
+		t.Error(err)
+	}
+	if err = authenticateWithConfig(sc); err != nil {
+		t.Error(err)
+	}
+
 	pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer pool.AssertSize(t, 0)
 	ctx = WithArrowAllocator(ctx, pool)
 
+	query := fmt.Sprintf(selectRandomGenerator, numrows)
+	rows, err := sc.QueryContext(ctx, query, []driver.NamedValue{})
+	if err != nil {
+		t.Error(err)
+	}
+	defer rows.Close()
+
+	// getting result batches
+	batches, err := rows.(*snowflakeRows).GetArrowBatches()
+	if err != nil {
+		t.Error(err)
+	}
+	numBatches := len(batches)
+	maxWorkers := 10 // enough for 3000 rows
+	type count struct {
+		m       sync.Mutex
+		recVal  int
+		metaVal int
+	}
+	cnt := count{recVal: 0}
+	var wg sync.WaitGroup
+	chunks := make(chan int, numBatches)
+
+	// kicking off download workers - each of which will call fetch on a different result batch
+	for w := 1; w <= maxWorkers; w++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, chunks <-chan int) {
+			defer wg.Done()
+
+			for i := range chunks {
+				rec, err := batches[i].Fetch()
+				if err != nil {
+					t.Error(err)
+				}
+				for _, r := range *rec {
+					cnt.m.Lock()
+					cnt.recVal += int(r.NumRows())
+					cnt.m.Unlock()
 					r.Release()
 				}
 				cnt.m.Lock()
@@ -478,6 +534,25 @@ func TestWithArrowBatchesAsync(t *testing.T) {
 					cnt.recVal += int(r.NumRows())
 					cnt.m.Unlock()
 					r.Release()
+				}
+				cnt.m.Lock()
+				cnt.metaVal += batches[i].rowCount
+				cnt.m.Unlock()
+			}
+		}(&wg, chunks)
+	}
+	for j := 0; j < numBatches; j++ {
+		chunks <- j
+	}
+	close(chunks)
+
+	// wait for workers to finish fetching and check row counts
+	wg.Wait()
+	if cnt.recVal != numrows {
+		t.Errorf("number of rows from records didn't match. expected: %v, got: %v", numrows, cnt.recVal)
+	}
+	if cnt.metaVal != numrows {
+		t.Errorf("number of rows from arrow batch metadata didn't match. expected: %v, got: %v", numrows, cnt.metaVal)
 	}
 }
 
@@ -568,3 +643,5 @@ func TestQueryArrowStream(t *testing.T) {
 	}
 	if meta != int64(numrows) {
 		t.Errorf("number of rows from batch metadata didn't match. expected: %v, got: %v", numrows, total)
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -167,6 +167,7 @@ type DBTest struct {
 }
 
 func (dbt *DBTest) mustQuery(query string, args ...interface{}) (rows *RowsExtended) {
+	dbt.T.Helper()
 	// handler interrupt signal
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
@@ -198,6 +199,7 @@ func (dbt *DBTest) mustQuery(query string, args ...interface{}) (rows *RowsExten
 }
 
 func (dbt *DBTest) mustQueryContext(ctx context.Context, query string, args ...interface{}) (rows *RowsExtended) {
+	dbt.T.Helper()
 	// handler interrupt signal
 	ctx, cancel := context.WithCancel(ctx)
 	c := make(chan os.Signal, 1)
@@ -229,6 +231,7 @@ func (dbt *DBTest) mustQueryContext(ctx context.Context, query string, args ...i
 }
 
 func (dbt *DBTest) mustQueryAssertCount(query string, expected int, args ...interface{}) {
+	dbt.T.Helper()
 	rows := dbt.mustQuery(query, args...)
 	cnt := 0
 	for rows.Next() {
@@ -240,6 +243,7 @@ func (dbt *DBTest) mustQueryAssertCount(query string, expected int, args ...inte
 }
 
 func (dbt *DBTest) fail(method, query string, err error) {
+	dbt.T.Helper()
 	if len(query) > 300 {
 		query = "[query too large to print]"
 	}
@@ -247,6 +251,7 @@ func (dbt *DBTest) fail(method, query string, err error) {
 }
 
 func (dbt *DBTest) mustExec(query string, args ...interface{}) (res sql.Result) {
+	dbt.T.Helper()
 	res, err := dbt.db.Exec(query, args...)
 	if err != nil {
 		dbt.fail("exec", query, err)
@@ -255,6 +260,7 @@ func (dbt *DBTest) mustExec(query string, args ...interface{}) (res sql.Result) 
 }
 
 func (dbt *DBTest) mustExecContext(ctx context.Context, query string, args ...interface{}) (res sql.Result) {
+	dbt.T.Helper()
 	res, err := dbt.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		dbt.fail("exec context", query, err)
@@ -263,6 +269,7 @@ func (dbt *DBTest) mustExecContext(ctx context.Context, query string, args ...in
 }
 
 func (dbt *DBTest) mustDecimalSize(ct *sql.ColumnType) (pr int64, sc int64) {
+	dbt.T.Helper()
 	var ok bool
 	pr, sc, ok = ct.DecimalSize()
 	if !ok {
@@ -272,6 +279,7 @@ func (dbt *DBTest) mustDecimalSize(ct *sql.ColumnType) (pr int64, sc int64) {
 }
 
 func (dbt *DBTest) mustFailDecimalSize(ct *sql.ColumnType) {
+	dbt.T.Helper()
 	var ok bool
 	if _, _, ok = ct.DecimalSize(); ok {
 		dbt.Fatalf("should not return decimal size. %v", ct)
@@ -279,6 +287,7 @@ func (dbt *DBTest) mustFailDecimalSize(ct *sql.ColumnType) {
 }
 
 func (dbt *DBTest) mustLength(ct *sql.ColumnType) (cLen int64) {
+	dbt.T.Helper()
 	var ok bool
 	cLen, ok = ct.Length()
 	if !ok {
@@ -288,6 +297,7 @@ func (dbt *DBTest) mustLength(ct *sql.ColumnType) (cLen int64) {
 }
 
 func (dbt *DBTest) mustFailLength(ct *sql.ColumnType) {
+	dbt.T.Helper()
 	var ok bool
 	if _, ok = ct.Length(); ok {
 		dbt.Fatalf("should not return length. %v", ct)
@@ -295,6 +305,7 @@ func (dbt *DBTest) mustFailLength(ct *sql.ColumnType) {
 }
 
 func (dbt *DBTest) mustNullable(ct *sql.ColumnType) (canNull bool) {
+	dbt.T.Helper()
 	var ok bool
 	canNull, ok = ct.Nullable()
 	if !ok {
@@ -304,6 +315,7 @@ func (dbt *DBTest) mustNullable(ct *sql.ColumnType) (canNull bool) {
 }
 
 func (dbt *DBTest) mustPrepare(query string) (stmt *sql.Stmt) {
+	dbt.T.Helper()
 	stmt, err := dbt.db.Prepare(query)
 	if err != nil {
 		dbt.fail("prepare", query, err)

--- a/export.go
+++ b/export.go
@@ -7,37 +7,56 @@ import (
 	"time"
 )
 
-// Types
+// The following comments make the linter happy...
+
+// ExecResponse exports execResponse
 type ExecResponse = execResponse
+
+// ExecResponseRowType exports execResponseRowType
 type ExecResponseRowType = execResponseRowType
+
+// ExecResponseChunk exports execResponseChunk
 type ExecResponseChunk = execResponseChunk
-type SnowflakeRows = snowflakeRows
+
+// RawSnowflakeRows exports the "raw" underlying snowflakeRows
+type RawSnowflakeRows = snowflakeRows
+
+// SnowflakeRestful exports snowflakeRestful
 type SnowflakeRestful = snowflakeRestful
+
+// SnowflakeValue exports snowflakeValue
 type SnowflakeValue = snowflakeValue
+
+// ChunkRowType exports chunkRowType
 type ChunkRowType = chunkRowType
+
+// SimpleTokenAccessor exports simpleTokenAccessor
 type SimpleTokenAccessor = simpleTokenAccessor
 
-// Methods
-
+// ArrowToValue exports arrowToValue
 var ArrowToValue = arrowToValue
 
+// GetExecResponse returns the ExecResponse
 func (sr *snowflakeRows) GetExecResponse() *ExecResponse {
 	return sr.execResp
 }
 
+// GetExecResponse returns the ExecResponse
 func (sr *snowflakeResult) GetExecResponse() *ExecResponse {
 	return sr.execResp
 }
 
-// Setter methods for unit testing
+// Setter method for unit testing
 func (sr *snowflakeRows) SetExecResponse(er *ExecResponse) {
 	sr.execResp = er
 }
 
+// Setter method for unit testing
 func (sr *snowflakeResult) SetExecResponse(er *ExecResponse) {
 	sr.execResp = er
 }
 
+// StringToValue exports stringToValue
 func StringToValue(dest *driver.Value, srcColumnMeta execResponseRowType, srcValue *string, loc *time.Location) error {
 	return stringToValue(dest, srcColumnMeta, srcValue, loc)
 }

--- a/observe.go
+++ b/observe.go
@@ -7,15 +7,16 @@ import (
 	"io"
 
 	"github.com/mailru/easyjson"
-	_ "github.com/mailru/easyjson/gen"
+	_ "github.com/mailru/easyjson/gen" // This is required to have go mod vendor not remove the package
 	"github.com/mailru/easyjson/jlexer"
 )
 
 const (
-	// limit http response to be 100MB to avoid overwhelming the scheduler
+	// ResponseBodyLimit limits http response to be 100MB to avoid overwhelming the scheduler
 	ResponseBodyLimit = 100 * 1024 * 1024
 )
 
+// ErrResponseTooLarge means the reponse is too large (thanks linter for these useful comments!)
 var ErrResponseTooLarge = fmt.Errorf("response is too large")
 
 func decodeResponse(body io.ReadCloser, resp interface{}) error {


### PR DESCRIPTION
### Description
* During the rebase there were some conflicts and the code didn't compile anymore:
    - In upstream, SnowflakeRows was exported as an interface, however we already use that name to export snowflakeRows. removed the upstream interface.
    - Tests TestWithArrowBatches and TestWithArrowBatchesAsync were modified in upstream and they now work. Reverted the removal from an earlier commit.
* Fixed linter issues which were just missing or malformed comments.
* Added calls to t.Helper() in driver_test.go to see the actual error origin.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary