### PR TITLE
Avoid nil pointer access due to empty chunk returned from gosnowflake.buildFirstArrowChunk

### DIFF
--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/apache/arrow/go/v12/arrow"
@@ -68,15 +69,15 @@ func (arc *arrowResultChunk) decodeArrowBatch(scd *snowflakeChunkDownloader) (*[
 }
 
 // Build arrow chunk based on RowSet of base64
-func buildFirstArrowChunk(rowsetBase64 string, loc *time.Location, alloc memory.Allocator) arrowResultChunk {
+func buildFirstArrowChunk(rowsetBase64 string, loc *time.Location, alloc memory.Allocator) (arrowResultChunk, error) {
 	rowSetBytes, err := base64.StdEncoding.DecodeString(rowsetBase64)
 	if err != nil {
-		return arrowResultChunk{}
+		return arrowResultChunk{}, fmt.Errorf("encountered error while decoding string %q: %v", rowsetBase64, err)
 	}
 	rr, err := ipc.NewReader(bytes.NewReader(rowSetBytes), ipc.WithAllocator(alloc))
 	if err != nil {
-		return arrowResultChunk{}
+		return arrowResultChunk{}, err
 	}
 
-	return arrowResultChunk{rr, 0, loc, alloc}
+	return arrowResultChunk{rr, 0, loc, alloc}, nil
 }

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -109,7 +109,10 @@ func (scd *snowflakeChunkDownloader) start() error {
 		if scd.sc != nil && scd.sc.cfg != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
-		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
+		firstArrowChunk, err := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
+		if err != nil {
+			return err
+		}
 		higherPrecision := higherPrecisionEnabled(scd.ctx)
 		scd.CurrentChunk, err = firstArrowChunk.decodeArrowChunk(scd.RowSet.RowType, higherPrecision)
 		scd.CurrentChunkSize = firstArrowChunk.rowCount
@@ -274,7 +277,10 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	if scd.sc != nil && scd.sc.cfg != nil {
 		loc = getCurrentLocation(scd.sc.cfg.Params)
 	}
-	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
+	firstArrowChunk, err := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
+	if err != nil {
+		return err
+	}
 	scd.FirstBatch = &ArrowBatch{
 		idx:                0,
 		scd:                scd,


### PR DESCRIPTION
### Description
Extended function `buildFirstArrowChunk` to also return an error, which when not nil is immediately returned by `*snowflakeChunkDownloader.start()` and `*snowflakeChunkDownloader.startArrowBatches()`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
