### PR TITLE
Fixes retryable errors.

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -390,6 +391,13 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 }
 
 func isRetryableError(req *http.Request, res *http.Response, err error) (bool, error) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		// Don't retry and return an unwrapped DeadlineExceeded error
+		return false, context.DeadlineExceeded
+	} else if errors.Is(err, context.Canceled) {
+		// Don't retry and return an unwrapped Canceled error
+		return false, context.Canceled
+	}
 	if err != nil && res == nil { // Failed http connection. Most probably client timeout.
 		return true, err
 	}


### PR DESCRIPTION
A context cancelation and a context expiration are both registered
as a retryable error. This forces the driver to repeat the query.

This PR handles cancelation and expiration by marking them as not
retryable errors.

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
